### PR TITLE
Add postinstall step to bootstrap child packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Development tools to bundle Titanium apps with Webpack",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "lerna bootstrap"
   },
   "keywords": [
     "webpack",


### PR DESCRIPTION
Just to avoid having run `npm install` in each directly