### PR TITLE
fix: replace NodeSourcePlugin with NodeTargetPlugin

### DIFF
--- a/packages/webpack-target-titanium/src/titanium-target.js
+++ b/packages/webpack-target-titanium/src/titanium-target.js
@@ -1,20 +1,17 @@
 'use strict';
 
 module.exports = function titaniumTarget(compiler) {
-	var options = this;
-	var webpackLib = 'webpack/lib';
+	const webpackLib = 'webpack/lib';
 
-	var TitaniumTemplatePlugin = require('./plugins/TitaniumTemplatePlugin');
+	const TitaniumTemplatePlugin = require('./plugins/TitaniumTemplatePlugin');
 	/* eslint-disable security/detect-non-literal-require */
-	var FunctionModulePlugin = require(webpackLib + '/FunctionModulePlugin');
-	var NodeSourcePlugin = require(webpackLib + '/node/NodeSourcePlugin');
-	var LoaderTargetPlugin = require(webpackLib + '/LoaderTargetPlugin');
+	const FunctionModulePlugin = require(webpackLib + '/FunctionModulePlugin');
+	const NodeTargetPlugin = require(webpackLib + '/node/NodeTargetPlugin');
+	const LoaderTargetPlugin = require(webpackLib + '/LoaderTargetPlugin');
 	/* eslint-enable security/detect-non-literal-require */
 
-	compiler.apply(
-		new TitaniumTemplatePlugin(options.output),
-		new FunctionModulePlugin(options.output),
-		new NodeSourcePlugin(options.node),
-		new LoaderTargetPlugin('web')
-	);
+	new TitaniumTemplatePlugin().apply(compiler);
+	new FunctionModulePlugin().apply(compiler);
+	new NodeTargetPlugin().apply(compiler);
+	new LoaderTargetPlugin('node').apply(compiler);
 };


### PR DESCRIPTION
Fixes a few issues in the Titanium target setup

- Use `apply` on the plugins instead of the compiler
- Replace `NodeSourcePlugin` with `NodeTargetPlugin`. Prevents unnecessary Node.js module polyfilling and automatically marks Node.js modules as externals.
- Set loader target to `node`