### PR TITLE
feat: titanium externals plugin

### DIFF
--- a/packages/webpack-target-titanium/src/index.js
+++ b/packages/webpack-target-titanium/src/index.js
@@ -3,9 +3,11 @@
 const GenerateAppJsPlugin = require('./plugins/GenerateAppJsPlugin');
 const PlatformResolverPlugin = require('./plugins/PlatformResolverPlugin');
 const titaniumTarget = require('./titanium-target');
+const TitaniumExternalsPlugins = require('./plugins/TitaniumExternalsPlugin');
 
 module.exports = {
 	GenerateAppJsPlugin,
 	PlatformResolverPlugin,
-	titaniumTarget
+	titaniumTarget,
+	TitaniumExternalsPlugins
 };

--- a/packages/webpack-target-titanium/src/plugins/TitaniumExternalsPlugin.js
+++ b/packages/webpack-target-titanium/src/plugins/TitaniumExternalsPlugin.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const ExternalsPlugin = require('webpack/lib/ExternalsPlugin');
+
+class TitaniumExternalsPlugin {
+	constructor(modules) {
+		this.modules = modules;
+	}
+
+	apply(compiler) {
+		const externals = [
+			'./app.js',
+			'com.appcelerator.aca',
+			...this.modules
+		];
+		new ExternalsPlugin('commonjs', externals).apply(compiler);
+	}
+}
+
+module.exports = TitaniumExternalsPlugin;


### PR DESCRIPTION
automatically marks used modules as external so webpack won't try to process them