### PR TITLE
fix(angular): add transformer if skipCodeGeneration is false

### DIFF
--- a/packages/webpack-titanium-angular/src/TitaniumAngularCompilerPlugin.js
+++ b/packages/webpack-titanium-angular/src/TitaniumAngularCompilerPlugin.js
@@ -12,7 +12,7 @@ const PlatformAwareFileSystem = require('./PlatformAwareFileSystem');
  */
 class TitaniumAngularCompilerPlugin extends AngularCompilerPlugin {
 	constructor(options) {
-		if (options.skipCodeGeneration) {
+		if (options.skipCodeGeneration === false) {
 			const platformTransforms = [];
 			const getEntryModule = () => this.entryModule
 			const getTypeChecker = () => this._getTsProgram().getTypeChecker()


### PR DESCRIPTION
`skipCodeGeneration` denotes that the compiler is in Jit mode. Therefore the bootstrap transformer only has to be added when `skipCodeGeneration` is `false`.